### PR TITLE
Fix broken links pointing to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ If your controller is pretty heavy, with a lot of functions, we recommend to cre
 
 * [Simple Lumie project](https://github.com/Alex-Levacher/Lumie/tree/master/example)
 * [Simple controller](https://github.com/Alex-Levacher/Lumie/blob/master/example/controllers/simple-ctrl.js)
-* [Structured controller](https://github.com/Alex-Levacher/Lumie/tree/master/example/controllers/users)
-* [Scalable structured controller](https://github.com/Alex-Levacher/Lumie/tree/master/example/controllers/cars)
+* [Structured controller](https://github.com/Alex-Levacher/Lumie/tree/master/example/controllers/user)
+* [Scalable structured controller](https://github.com/Alex-Levacher/Lumie/tree/master/example/controllers/car)
 
 ## 🚀 ROADMAP
 


### PR DESCRIPTION
Hey,

Your links pointing toward _structured controller_ & _scalable structured controller_ sample in the README.MD were broken since directories have been renamed (here d9cb4ff3ae98e3c679f02654dc9a4802c6d77037). This pull-request just fix it.

Awesome project by the way !