### PR TITLE
Fix Path Option

### DIFF
--- a/example/controllers/index.js
+++ b/example/controllers/index.js
@@ -1,0 +1,14 @@
+
+const index = (req, res) => {
+    res.json({ msg: 'I am an exemple of route with the path option' });
+};
+
+module.exports = {
+    path: '/',
+    '/': {
+        get: {
+            action: index,
+            level: 'public'
+        }
+    }
+};

--- a/example/controllers/index.js
+++ b/example/controllers/index.js
@@ -1,6 +1,6 @@
 
 const index = (req, res) => {
-    res.json({ msg: 'I am an exemple of route with the path option' });
+    res.json({ msg: 'I am an example of route with the path option' });
 };
 
 module.exports = {

--- a/example/controllers/index.spec.js
+++ b/example/controllers/index.spec.js
@@ -8,5 +8,5 @@ test('[GET] / pass', async (t) => {
     .set('Accept', 'application/json');
 
     t.is(status, 200);
-    t.is(body.msg, 'I am an exemple of route with the path option');
+    t.is(body.msg, 'I am an example of route with the path option');
 });

--- a/example/controllers/index.spec.js
+++ b/example/controllers/index.spec.js
@@ -1,0 +1,12 @@
+const test = require('ava');
+const request = require('supertest');
+const app = require('../app');
+
+test('[GET] / pass', async (t) => {
+    const { body, status } = await request(app)
+    .get('/api/')
+    .set('Accept', 'application/json');
+
+    t.is(status, 200);
+    t.is(body.msg, 'I am an exemple of route with the path option');
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,20 +11,18 @@ const _routes = {};
 const _options = {};
 
 function browseControllerObject(ctrlDefinition, path) {
-    let routeSlug = null;
-
     const keyName = path.split('/')
     .filter(item => (item && item !== _options.preURL))
     .map(item => capitalize(item))
     .join(' > ');
 
     _routes[keyName] = {};
+    if (ctrlDefinition.path) delete ctrlDefinition.path;
     for (const actionName in ctrlDefinition) {
-        if (actionName === 'path') break;
         const action = ctrlDefinition[actionName];
         for (const verbName in action) {
-            routeSlug = cpath.join(verbName, path, actionName);
-            _routes[keyName][routeSlug] = new Route({
+            const routeID = cpath.join(verbName, path, actionName);
+            _routes[keyName][routeID] = new Route({
                 verb: verbName,
                 action: action[verbName].action,
                 level: action[verbName].level,


### PR DESCRIPTION
PR #18 helped me spot that the "path" option didn't work as expected. Now it's possible to use it as shown below:

controllers > index.js
```js
module.exports = {
    path: '/', // note that you can set the path you want here in order to rename 'index'
    '/': {
        get: {
            action: index,
            level: 'public'
        }
    }
};
```
will output with `api` as a preUrl:
```
public	get	[/api/]
```
instead of:
```
public	get	[/api/index]
```